### PR TITLE
Fixes for typos, and self-signed SSL installations

### DIFF
--- a/instantpy/instantpy.py
+++ b/instantpy/instantpy.py
@@ -20,9 +20,9 @@ def autologin(func):
 class InstantVC:
     def __init__(
         self,
-        ip,
         username,
         password,
+        ip,
         port=4343,
         template_basepath="templates/",
         ssl_verify=True,
@@ -37,7 +37,7 @@ class InstantVC:
         Keyword Arguments:
             port {int} -- Listening port of the VC webserver (default: {4343})
             template_basepath {str} -- Base path for template configs (default: {"templates/"})
-            ssl_verify {bool} -- Verify SSL certificate returned by VC (default: {False})
+            ssl_verify {bool} -- Verify SSL certificate returned by VC (default: {True})
         """
         self.username = username
         self.password = password
@@ -45,7 +45,7 @@ class InstantVC:
         self.ip = ip
         self.logged_in = False
         self.sid = None
-        self._session = None
+        self.session = requests.Session()
         self.baseurl = f"https://{ip}:{port}/rest"
         self.template_basepath = template_basepath
         self.ssl_verify = ssl_verify
@@ -61,6 +61,8 @@ class InstantVC:
         creds = {"user": self.username, "passwd": self.password}
         try:
             with requests.Session() as session:
+                if not self.ssl_verify:
+                    requests.packages.urllib3.disable_warnings()
                 response = session.post(
                     url, json=creds, headers=self.headers, verify=self.ssl_verify
                 )


### PR DESCRIPTION
### Typos
- comment on line 40 stated that `ssl_verify` was `False` by default, but is actually `True` by default on line 28
- typo for `self._session` on line 48 - should be `self.session`

### Fixes
- `ip` argument on line 23 is positional, creating problems for `username` and `password` arguments - moved (another fix could be to make `username`,`password`, and `ip` all keywords
- problem with `InstantVC` - was expecting a `session` attribute, which was set to `None` on line 48 (after fixing above typo), now instantiated as `requests.Session()` object
- added a check at line 64 so that, if someone turns off `ssl_verify` via the keyword when calling any function, it disables warnings via the `urllib3` package on line 65 - this will fix the warnings for the default, self-signed SSL certs