### PR TITLE
fixed typo in url for 11a radio settings

### DIFF
--- a/instantpy/instantpy.py
+++ b/instantpy/instantpy.py
@@ -649,7 +649,7 @@ class InstantVC:
         Returns:
             dict -- Json formmated response from VC
         """
-        url = f"{self.baseurl}/syslog-server"
+        url = f"{self.baseurl}/radio-profile-11a"
         with open(self.template_basepath + template, "r") as f:
             data = f.read()
         response = self.session.post(


### PR DESCRIPTION
url was set to syslog , probably a typo. 
Tested and it works now.